### PR TITLE
chore: add GitHub issue templates (Task & Bug report)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Description
+        A clear and concise description of what the bug is.
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the behavior?
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+      render: markdown
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain.
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Provide environment info (OS, Go version, etc.)
+      placeholder: "e.g., Windows 11, Go 1.22"

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -1,0 +1,31 @@
+name: Task
+description: Use this template for project tasks
+title: "[Task]: "
+labels: ["task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Goal
+        Describe the goal of this task.
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: Checklist items for this task
+      placeholder: "- [ ] Item 1"
+      render: markdown
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Define what must be true to consider this task done
+      render: markdown
+
+  - type: textarea
+    id: outofscope
+    attributes:
+      label: Out of scope
+      description: Define what is NOT part of this task


### PR DESCRIPTION
## Summary
Add `.github/ISSUE_TEMPLATE/` with templates to standardize new issues.

## Details
- task.yaml: Goal, Tasks, Acceptance Criteria, Out of scope
- bug.yaml: Description, Steps to Reproduce, Expected behavior, Screenshots, Environment
