### PR TITLE
feat(errors): idiomatic error wrapping + kin-openapi normalization (main <- dev)

### DIFF
--- a/internal/application/customerrors/app_error.go
+++ b/internal/application/customerrors/app_error.go
@@ -1,64 +1,92 @@
 package customerrors
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
 
-// ErrorType classifies an application error so callers can branch on intent
-// (e.g., validation vs. infrastructure/dependency failures).
 type ErrorType string
 
 const (
-	// VALIDATION_ERROR indicates user/input/spec validation issues that the
-	// caller can typically fix (bad format, unsupported values, etc.).
 	VALIDATION_ERROR ErrorType = "validation"
-
-	// DEPENDENCY_ERROR indicates a missing or misconfigured component the app
-	// depends on (adapters, services, environment), not user input.
 	DEPENDENCY_ERROR ErrorType = "dependency"
 )
 
-// AppError represents a structured domain error used across the application.
+// Reserved detail keys for consistent logging/telemetry.
+const (
+	DetailFile      = "file"
+	DetailKind      = "kind"
+	DetailVersion   = "version"
+	DetailComponent = "component"
+	DetailExpected  = "expected"
+)
+
+// AppError is the central application error.
+// - Message: stable, user-facing summary.
+// - Details: structured context (use reserved keys when applicable).
+// - cause: wrapped technical cause (used by errors.Is/As via Unwrap()).
 type AppError struct {
 	Type    ErrorType
 	Message string
-	Cause   string
-	Details map[string]interface{}
+	Details map[string]any
+	cause   error
 }
 
-// Error satisfies the error interface, producing a concise, readable summary.
 func (e *AppError) Error() string {
-	return fmt.Sprintf("[%s] %s: %s", e.Type, e.Message, e.Cause)
+	if e.cause == nil {
+		return fmt.Sprintf("[%s] %s", e.Type, e.Message)
+	}
+	return fmt.Sprintf("[%s] %s: %v", e.Type, e.Message, e.cause)
 }
 
-// NewDependencyError builds a standardized DEPENDENCY_ERROR for a missing
-// or required external component.
+// Unwrap exposes the wrapped technical cause for errors.Is/As.
+func (e *AppError) Unwrap() error { return e.cause }
+
+// NewValidationError creates a VALIDATION_ERROR and wraps the technical cause.
+// Caller MUST provide a non-nil cause; it is used for errors.Is/As lookups.
+// If cause is nil, a defensive placeholder is created.
+func NewValidationError(message string, cause error, details map[string]any) error {
+	if cause == nil {
+		cause = errors.New("missing technical cause for validation error")
+	}
+	return &AppError{
+		Type:    VALIDATION_ERROR,
+		Message: message,
+		Details: cloneDetails(details),
+		cause:   cause,
+	}
+}
+
+// NewDependencyError builds a standardized DEPENDENCY_ERROR with a wrapped cause.
 func NewDependencyError(component string) error {
+	cause := fmt.Errorf("dependency %q is required", component)
 	return &AppError{
 		Type:    DEPENDENCY_ERROR,
 		Message: "Missing required dependency",
-		Cause:   fmt.Sprintf("dependency '%s' is required", component),
-	}
-}
-
-// NewUnsupportedVersionError builds a VALIDATION_ERROR indicating that an
-// input (e.g., OpenAPI file) declares an unsupported major version.
-// expectedMajors should contain allowed major versions (e.g., []int{3}).
-func NewUnsupportedVersionError(file, got string, expectedMajors []int) error {
-	return &AppError{
-		Type:    VALIDATION_ERROR,
-		Message: "Unsupported OpenAPI version",
-		Cause:   fmt.Sprintf("got %s, expected one of: %s", got, formatMajors(expectedMajors)),
-		Details: map[string]interface{}{
-			"file":     file,
-			"version":  got,
-			"expected": expectedMajors,
+		Details: map[string]any{
+			DetailComponent: component,
 		},
+		cause: cause,
 	}
 }
 
-// formatMajors renders majors like [3,4] as "3.x, 4.x" for user-friendly messages.
+// NewUnsupportedVersionError builds a VALIDATION_ERROR indicating an unsupported major version.
+// expectedMajors should contain allowed majors (e.g., []int{3}).
+func NewUnsupportedVersionError(file, got string, expectedMajors []int) error {
+	cause := fmt.Errorf("got %s, expected one of: %s", got, formatMajors(expectedMajors))
+	return NewValidationError(
+		"Unsupported OpenAPI version",
+		cause,
+		map[string]any{
+			DetailFile:     file,
+			DetailVersion:  got,
+			DetailExpected: expectedMajors,
+		},
+	)
+}
+
+// formatMajors renders majors like [3,4] as "3.x, 4.x".
 func formatMajors(majors []int) string {
 	if len(majors) == 0 {
 		return ""
@@ -68,4 +96,16 @@ func formatMajors(majors []int) string {
 		parts[i] = fmt.Sprintf("%d.x", m)
 	}
 	return strings.Join(parts, ", ")
+}
+
+// cloneDetails returns a non-nil shallow copy of details.
+func cloneDetails(in map[string]any) map[string]any {
+	if in == nil {
+		return make(map[string]any, 1)
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }

--- a/internal/application/ports/output/openapi/errors.go
+++ b/internal/application/ports/output/openapi/errors.go
@@ -3,46 +3,29 @@ package openapi
 import "github.com/betoth/contractcheck/internal/application/customerrors"
 
 // ErrorKind classifies validation failures for OpenAPI import/validation flows.
-// Keep values stable: UI, telemetry, and branching logic rely on these identifiers.
 type ErrorKind string
 
 const (
-	// FILE_NOT_FOUND indicates the path does not exist on disk.
-	FILE_NOT_FOUND ErrorKind = "file_not_found"
-
-	// PERMISSION_DENIED indicates the process lacks permissions to read the file.
-	PERMISSION_DENIED ErrorKind = "permission_denied"
-
-	// INVALID_SYNTAX indicates YAML/JSON parsing errors.
-	INVALID_SYNTAX ErrorKind = "invalid_syntax"
-
-	// EXTERNAL_REF_NOT_ALLOWED indicates a policy violation for external $ref usage.
+	FILE_NOT_FOUND           ErrorKind = "file_not_found"
+	PERMISSION_DENIED        ErrorKind = "permission_denied"
+	INVALID_SYNTAX           ErrorKind = "invalid_syntax"
 	EXTERNAL_REF_NOT_ALLOWED ErrorKind = "external_ref_not_allowed"
-
-	// INVALID_SPEC indicates a semantically invalid OpenAPI document (failed validation).
-	INVALID_SPEC ErrorKind = "invalid_spec"
-
-	// INTERNAL_ERROR is a catch-all for unexpected failures not attributable to user input.
-	// Prefer more specific kinds whenever possible.
-	INTERNAL_ERROR ErrorKind = "internal_error"
-
-	// INVALID_VERSION_FORMAT indicates an invalid "openapi" version string (e.g., not X.Y[.Z]).
-	INVALID_VERSION_FORMAT ErrorKind = "invalid_version_format"
+	INVALID_SPEC             ErrorKind = "invalid_spec"
+	INVALID_VERSION_FORMAT   ErrorKind = "invalid_version_format"
 )
 
-// NewValidationError creates a structured VALIDATION_ERROR using our domain error type.
-// - kind: machine-readable classification (use one of the constants above)
-// - message: short human-readable summary (safe to show to users)
+// NewValidationError wraps a technical cause and returns a standardized validation error.
+// - kind: machine-readable classification
+// - message: stable, user-facing summary
 // - file: source file path for context (optional but recommended)
-// - cause: low-level detail for diagnostics (keep technical; not required for UX)
-func NewValidationError(kind ErrorKind, message string, file string, cause string) error {
-	return &customerrors.AppError{
-		Type:    customerrors.VALIDATION_ERROR,
-		Message: message,
-		Cause:   cause,
-		Details: map[string]interface{}{
-			"kind": kind,
-			"file": file,
+// - cause: required technical cause (used by errors.Is/As)
+func NewValidationError(kind ErrorKind, message, file string, cause error) error {
+	return customerrors.NewValidationError(
+		message,
+		cause,
+		map[string]any{
+			customerrors.DetailKind: string(kind),
+			customerrors.DetailFile: file,
 		},
-	}
+	)
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -4,19 +4,62 @@ package config
 import (
 	"errors"
 	"fmt"
+	"sort"
 )
 
-// ErrConfigInvalid signals a structurally valid file whose semantic values
+// ErrConfigInvalid is a sentinel error indicating the configuration failed validation.
 var ErrConfigInvalid = errors.New("invalid config")
 
 // LoadAppConfig returns the effective application configuration.
-// For now, we rely on in-process defaults (see config.Default).
 func LoadAppConfig() (*AppConfig, error) {
 	cfg := Default()
 
-	if len(cfg.OpenAPI.SupportedMajors) == 0 {
-		return nil, fmt.Errorf("%w: config field openapi.supported_majors: must not be empty", ErrConfigInvalid)
+	if err := normalizeAndValidate(&cfg); err != nil {
+		return nil, err
 	}
 
 	return &cfg, nil
+}
+
+// normalizeAndValidate applies canonicalization (dedup/sort) and validates invariants.
+func normalizeAndValidate(cfg *AppConfig) error {
+	cfg.OpenAPI.SupportedMajors = normalizeMajors(cfg.OpenAPI.SupportedMajors)
+
+	if len(cfg.OpenAPI.SupportedMajors) == 0 {
+		return fieldErr("openapi.supported_majors", "must not be empty")
+	}
+
+	for _, m := range cfg.OpenAPI.SupportedMajors {
+		if m <= 0 {
+			return fieldErr("openapi.supported_majors", "must contain only positive integers (e.g., 3 for 3.x)")
+		}
+	}
+
+	return nil
+}
+
+// fieldErr wraps ErrConfigInvalid with a field-specific, actionable message.
+func fieldErr(field, msg string) error {
+	return fmt.Errorf("%w: field %q %s", ErrConfigInvalid, field, msg)
+}
+
+// normalizeMajors removes duplicates and non-positive values, then sorts ascending.
+func normalizeMajors(in []int) []int {
+	if len(in) == 0 {
+		return in
+	}
+	seen := make(map[int]struct{}, len(in))
+	out := make([]int, 0, len(in))
+	for _, v := range in {
+		if v <= 0 {
+			continue
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Ints(out)
+	return out
 }


### PR DESCRIPTION
## Summary
- Replace string Cause with wrapped error + Unwrap()
- Add NewValidationError(message, cause, details)
- KinLoader maps errors via port ErrorKind and preserves original cause
- Config loader: normalize/validate supported_majors; sentinel ErrConfigInvalid

BREAKING: AppError.Cause (string) removed — use errors.Is/As and Details.

## Context
Closes #23 